### PR TITLE
[OYS-57] Create openy_google_search module with configuration settings form

### DIFF
--- a/modules/custom/openy_search/openy_google_search/config/install/openy_google_search.settings.yml
+++ b/modules/custom/openy_search/openy_google_search/config/install/openy_google_search.settings.yml
@@ -1,0 +1,1 @@
+google_engine_id: ''

--- a/modules/custom/openy_search/openy_google_search/openy_google_search.info.yml
+++ b/modules/custom/openy_search/openy_google_search/openy_google_search.info.yml
@@ -1,0 +1,6 @@
+name: Open Y Google Search
+type: module
+description: Provides a Google Custom search Engine for Open Y.
+core: 8.x
+package: Open Y
+version: 8.x-1.0

--- a/modules/custom/openy_search/openy_google_search/openy_google_search.links.menu.yml
+++ b/modules/custom/openy_search/openy_google_search/openy_google_search.links.menu.yml
@@ -1,0 +1,6 @@
+openy_google_search.admin:
+  title: 'Google Search settings'
+  description: 'Configure Open Y Google Custom Search settings.'
+  parent: openy_system.openy_settings
+  route_name: openy_google_search.settings
+  weight: 100

--- a/modules/custom/openy_search/openy_google_search/openy_google_search.routing.yml
+++ b/modules/custom/openy_search/openy_google_search/openy_google_search.routing.yml
@@ -1,0 +1,7 @@
+openy_google_search.settings:
+  path: '/admin/openy/settings/google-search'
+  defaults:
+    _form: '\Drupal\openy_google_search\Form\SettingsForm'
+    _title: 'Google Search settings'
+  requirements:
+    _permission: 'administer google custom search'

--- a/modules/custom/openy_search/openy_google_search/src/Form/SettingsForm.php
+++ b/modules/custom/openy_search/openy_google_search/src/Form/SettingsForm.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Drupal\openy_google_search\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Settings Form for openy_google_search.
+ */
+class SettingsForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'openy_google_search_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'openy_google_search.settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('openy_google_search.settings');
+
+    $form['google_engine_id'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Google Search Engine ID'),
+      '#size' => 40,
+      '#default_value' => !empty($config->get('google_engine_id')) ? $config->get('google_engine_id') : '',
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $values = $form_state->getValues();
+    $config = $this->config('openy_google_search.settings');
+    $config->set('google_engine_id', $values['google_engine_id']);
+    $config->save();
+
+    parent::submitForm($form, $form_state);
+  }
+
+}


### PR DESCRIPTION
Jira issue https://fivejars.atlassian.net/browse/OYS-57

Original Issue, this PR is going to fix: REPLACE WITH A LINK TO ISSUE ( publicly available )


## Steps for review

- [ ] login as admin
- [ ] visit Extend admin menu and enable module Open Y Google Search.
- [ ] visit page admin/openy/settings/google-search (menu Open Y- Settings - Google Search Settings).
- [ ] make sure configuration form with engine Id displayed and works correctly.


