### PR TITLE
[OYS-58] Add google search block and paragraph to render it

### DIFF
--- a/modules/custom/openy_search/openy_google_search/js/google_search.js
+++ b/modules/custom/openy_search/openy_google_search/js/google_search.js
@@ -1,0 +1,22 @@
+/**
+ * @file
+ */
+
+(function ($) {
+
+  Drupal.behaviors.google_search = {
+    attach: function (context, settings) {
+      // Only run this script on full documents, not ajax requests.
+      if (context !== document) {
+        return;
+      }
+      var gcse = document.createElement('script');
+      gcse.type = 'text/javascript';
+      gcse.async = true;
+      gcse.src = 'https://cse.google.com/cse.js?cx=' + settings.engine_id;
+      var s = document.getElementsByTagName('script')[0];
+      s.parentNode.insertBefore(gcse, s);
+    }
+  };
+
+}(jQuery));

--- a/modules/custom/openy_search/openy_google_search/openy_google_search.libraries.yml
+++ b/modules/custom/openy_search/openy_google_search/openy_google_search.libraries.yml
@@ -1,0 +1,7 @@
+google_search:
+  version: 1.x
+  js:
+    js/google_search.js: {}
+  dependencies:
+    - core/jquery
+    - core/drupalSettings

--- a/modules/custom/openy_search/openy_google_search/openy_google_search.module
+++ b/modules/custom/openy_search/openy_google_search/openy_google_search.module
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @file
+ * Contains module routines.
+ */
+
+/**
+ * Implements hook_theme().
+ */
+function openy_google_search_theme($existing, $type, $theme, $path) {
+  return [
+    'openy_google_search' => [],
+  ];
+}

--- a/modules/custom/openy_search/openy_google_search/src/Plugin/Block/GoogleSearchBlock.php
+++ b/modules/custom/openy_search/openy_google_search/src/Plugin/Block/GoogleSearchBlock.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Drupal\openy_google_search\Plugin\Block;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Messenger\MessengerTrait;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Block\BlockBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a 'Google Search Block' block.
+ *
+ * @Block(
+ *   id = "google_search_block",
+ *   admin_label = @Translation("Google Search Block"),
+ *   category = @Translation("Paragraph Blocks")
+ * )
+ */
+class GoogleSearchBlock extends BlockBase implements ContainerFactoryPluginInterface {
+  use MessengerTrait;
+  /**
+   * The config factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Constructs a new Programs Search Block instance.
+   *
+   * @param array $configuration
+   *   The plugin configuration.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ConfigFactoryInterface $config_factory) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $engine_id = $this->configFactory->get('openy_google_search.settings')->get('google_engine_id');
+    if (empty($engine_id)) {
+      $this->messenger()->addError('Please set ENGINE_ID in the search settings.');
+      return NULL;
+    }
+
+    return [
+      '#theme' => 'openy_google_search',
+      '#cache' => [
+        'tags' => ['config:openy_google_search.settings'],
+      ],
+      '#attached' => [
+        'library' => ['openy_google_search/google_search'],
+        'drupalSettings' => [
+          'engine_id' => $engine_id,
+        ],
+      ],
+    ];
+  }
+
+}

--- a/modules/custom/openy_search/openy_google_search/templates/openy-google-search.html.twig
+++ b/modules/custom/openy_search/openy_google_search/templates/openy-google-search.html.twig
@@ -1,0 +1,1 @@
+<div class="gcse-search"></div>

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_google_search/config/install/core.entity_form_display.paragraph.google_search.default.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_google_search/config/install/core.entity_form_display.paragraph.google_search.default.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.google_search.field_prgf_block
+    - paragraphs.paragraphs_type.google_search
+  module:
+    - plugin
+id: paragraph.google_search.default
+targetEntityType: paragraph
+bundle: google_search
+mode: default
+content:
+  field_prgf_block:
+    type: 'plugin_selector:plugin_autocomplete_list'
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_google_search/config/install/core.entity_view_display.paragraph.google_search.default.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_google_search/config/install/core.entity_view_display.paragraph.google_search.default.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.google_search.field_prgf_block
+    - paragraphs.paragraphs_type.google_search
+  module:
+    - plugin
+id: paragraph.google_search.default
+targetEntityType: paragraph
+bundle: google_search
+mode: default
+content:
+  field_prgf_block:
+    type: plugin_block_built
+    weight: 0
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  search_api_excerpt: true
+  uid: true

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_google_search/config/install/field.field.paragraph.google_search.field_prgf_block.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_google_search/config/install/field.field.paragraph.google_search.field_prgf_block.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_prgf_block
+    - paragraphs.paragraphs_type.google_search
+  module:
+    - plugin
+id: paragraph.google_search.field_prgf_block
+field_name: field_prgf_block
+entity_type: paragraph
+bundle: google_search
+label: Block
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    plugin_id: google_search_block
+    plugin_configuration:
+      id: google_search_block
+      label: Block
+      provider: null
+      label_display: null
+    plugin_configuration_schema_id: block.settings.google_search_block
+default_value_callback: ''
+settings: {  }
+field_type: 'plugin:block'

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_google_search/config/install/paragraphs.paragraphs_type.google_search.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_google_search/config/install/paragraphs.paragraphs_type.google_search.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: google_search
+label: 'Google Search'
+icon_uuid: null
+description: 'Paragraph to display Google Custom Search block'
+behavior_plugins: {  }

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_google_search/openy_prgf_google_search.features.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_google_search/openy_prgf_google_search.features.yml
@@ -1,0 +1,1 @@
+required: true

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_google_search/openy_prgf_google_search.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_google_search/openy_prgf_google_search.info.yml
@@ -1,0 +1,18 @@
+name: 'Open Y Paragraph Google Search'
+description: 'Provides a paragraph to render Google Search block.'
+type: module
+core: 8.x
+package: 'Open Y'
+version: 8.x-1.0
+dependencies:
+  - 'address:address'
+  - 'drupal:block'
+  - 'drupal:field'
+  - 'drupal:node'
+  - 'drupal:user'
+  - 'entity_reference_revisions:entity_reference_revisions'
+  - openy_prgf
+  - openy_google_search
+  - 'paragraphs:paragraphs'
+  - 'plugin:plugin'
+core_incompatible: false


### PR DESCRIPTION
https://fivejars.atlassian.net/browse/OYS-58

## Steps for review

- [ ] login as admin
- [ ]  visit Extend admin menu and enable module Open Y Google Search.
 - [ ] visit page admin/openy/settings/google-search (menu Open Y- Settings - Google Search Settings)
- [ ] insert to id field value 016871164121624642208:hiywwaohyuc (this is id for searching at YMCA Seattle site for testing purposes)
- [ ] create new landing page using link /node/add/landing_page
- [ ] expand content area and select Add Google Search 
- [ ] fill page title and select any layout and save page
- [ ] make sure you see saved page with search form from Google Custom Search

![image](https://user-images.githubusercontent.com/16559938/73017199-06af7f00-3e28-11ea-84ff-cf8a56b943ad.png)

- [ ] visit page admin/openy/settings/google-search and empty engine id field
- [ ] save configuration and return to site
- [ ] make sure you see error message `Please set ENGINE_ID in the search settings`