### PR TITLE
[OYS-59] Lily: Add search form to page header and mobile menu

### DIFF
--- a/openy.install
+++ b/openy.install
@@ -1015,7 +1015,7 @@ function openy_update_8069() {
     $config_importer->update($config, 'openy_carnation.settings', 'display_search_form');
   }
 }
- 
+
  /**
  * Import config with T&C.
  */
@@ -1054,5 +1054,23 @@ function openy_update_8076() {
     \Drupal::service('module_installer')->install([
       $module,
     ]);
+  }
+}
+
+/**
+ * Update themes settings: add search form query key.
+ */
+function openy_update_8077() {
+  $themes_list = [
+    'openy_lily',
+    'openy_carnation'
+  ];
+  foreach ($themes_list as $theme) {
+    if (\Drupal::service('theme_handler')->themeExists($theme)) {
+      $config = drupal_get_path('theme', $theme) . '/config/install/' . $theme . '.settings.yml';
+      /** @var Drupal\openy_upgrade_tool\ConfigParamUpgradeTool $config_importer */
+      $config_importer = \Drupal::service('openy_upgrade_tool.param_updater');
+      $config_importer->update($config, $theme . '.settings', 'search_query_key');
+    }
   }
 }

--- a/themes/openy_themes/openy_lily/config/install/openy_lily.settings.yml
+++ b/themes/openy_themes/openy_lily/config/install/openy_lily.settings.yml
@@ -15,6 +15,8 @@ openy_lily_image_fields:
   camp_favicon: openy_lily_camp_favicon
 css_enabled: 1
 css: ""
+display_search_form: 1
+search_query_key: search
 plaintext_enabled: 0
 autopreview_enabled: 0
 preview_path: ''

--- a/themes/openy_themes/openy_lily/openy_lily.theme
+++ b/themes/openy_themes/openy_lily/openy_lily.theme
@@ -193,6 +193,19 @@ function openy_lily_form_system_theme_settings_alter(array &$form, FormStateInte
     return;
   }
 
+  $form['search'] = [
+    '#type' => 'details',
+    '#title' => t('Search'),
+    '#open' => TRUE,
+  ];
+
+  $form['search']['display_search_form'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Display the search form'),
+    '#default_value' => theme_get_setting('display_search_form'),
+    '#description' => t('Show search form in the header'),
+  ];
+
   $form['camp_section'] = array(
     '#type' => 'details',
     '#title' => t('Camp section'),
@@ -423,6 +436,10 @@ function openy_lily_preprocess_page(&$variables) {
       'menuSelector' => '.nav-global .secondary_menu ul.navbar-nav, .mobile_menu ul.nav-level-1',
     ]);
   }
+
+  $variables['display_search'] = theme_get_setting('display_search_form');
+  $variables['search_key'] = theme_get_setting('search_query_key');
+
 }
 
 /**
@@ -457,7 +474,14 @@ function openy_lily_theme_suggestions_form_alter(array &$suggestions, array $var
 }
 
 /**
- * Implements hook_preprocess_HOOK() for footer menus.
+ * Implements hook_preprocess_menu_HOOK() for account menu.
+ */
+function openy_lily_preprocess_menu__account(&$variables) {
+  $variables['display_search'] = theme_get_setting('display_search_form');
+}
+
+/**
+ * Implements hook_preprocess_menu_HOOK() for footer menus.
  */
 function openy_lily_preprocess_menu__footer_menus(&$variables) {
   $variables['#cache']['contexts'][] = 'url.path';

--- a/themes/openy_themes/openy_lily/templates/include/sidebar-search-and-menu.html.twig
+++ b/themes/openy_themes/openy_lily/templates/include/sidebar-search-and-menu.html.twig
@@ -9,7 +9,7 @@
   <form method="get" action="{{ search_view_content_path }}">
     <div class="form-group col-xs-12">
       <div class="input-group">
-        <input type="text" name="search" class="form-control">
+        <input type="text" name="{{ search_key }}" class="form-control">
         <span class="input-group-btn">
           <button class="btn btn-info" aria-label="Search submit" type="submit">{{ "SEARCH THE Y"|t }}</button>
         </span>

--- a/themes/openy_themes/openy_lily/templates/include/site-search.html.twig
+++ b/themes/openy_themes/openy_lily/templates/include/site-search.html.twig
@@ -3,20 +3,21 @@
  * @file
  * Contains site search form static template.
  */
- @todo seems this template is unused.
 #}
-<article class="hidden-xs ">
-  <div id="site-search" class="site-search collapse">
-    <div class="container search-container">
-      <form action="{{ search_view_content_path }}" method="get">
-        <div class="input-group">
-          <input type="text" aria-label="Search input" name="q" class="form-control input-lg">
-          <span class="input-group-btn">
-              <button class="btn btn-primary btn-lg" aria-label="Search submit" type="submit">{{ "Search The Y"|t }}</button>
-          </span>
-        </div>
-        <!-- /input-group -->
-      </form>
+{% if display_search %}
+  <article class="hidden-xs ">
+    <div id="site-search" class="site-search collapse">
+      <div class="container search-container">
+        <form action="{{ search_view_content_path }}" method="get">
+          <div class="input-group">
+            <input type="text" aria-label="Search input" name="{{ search_key }}" class="form-control input-lg">
+            <span class="input-group-btn">
+                <button class="btn btn-primary btn-lg" aria-label="Search submit" type="submit">{{ "Search The Y"|t }}</button>
+            </span>
+          </div>
+          <!-- /input-group -->
+        </form>
+      </div>
     </div>
-  </div>
-</article>
+  </article>
+{% endif %}

--- a/themes/openy_themes/openy_lily/templates/menu/menu--account.html.twig
+++ b/themes/openy_themes/openy_lily/templates/menu/menu--account.html.twig
@@ -20,7 +20,9 @@
  * @ingroup themeable
  */
 #}
-<div class="search-toggle"><span class="glyphicon glyphicon-search"></span></div>
+{% if display_search %}
+ <div class="search-toggle"><span class="glyphicon glyphicon-search"></span></div>
+{% endif %}
 {% import _self as menus %}
 
 {#

--- a/themes/openy_themes/openy_lily/templates/page/page--header.html.html.twig
+++ b/themes/openy_themes/openy_lily/templates/page/page--header.html.html.twig
@@ -109,7 +109,7 @@
                     {{ page.search }}
                     <form method="get" action="{{ base_path }}search">
                       <i class="fa fa-search search-input-decoration" aria-hidden="true"></i>
-                      <input type="search" name="query" class="search-input" placeholder="Search">
+                      <input type="search" name="{{ search_key }}" class="search-input" placeholder="Search">
                       <input type="submit" value="Search">
                     </form>
                     <a href="#" data-target=".page-head__search" data-toggle="collapse" class="page-head__search-close">

--- a/themes/openy_themes/openy_lily/templates/page/page.html.twig
+++ b/themes/openy_themes/openy_lily/templates/page/page.html.twig
@@ -61,16 +61,19 @@
   {% include "@openy_lily/include/sidebar-search-and-menu.html.twig" %}
   <div id="side-area" aria-hidden="true">
     <div class="top-side">
-      <form class="clearfix" method="get" action="{{ search_view_content_path }}">
-        <div class="form-group">
-          <div class="input-group">
-            <input type="text" name="search" class="form-control">
-            <span class="input-group-btn">
-            <button class="btn btn-info" type="submit">{{ "SEARCH"|t }}</button>
-          </span>
+      {% if display_search %}
+        <form class="clearfix" method="get" action="{{ search_view_content_path }}">
+          <div class="form-group">
+            <div class="input-group">
+              <input type="text" name="{{ search_key }}" class="form-control">
+              <span class="input-group-btn">
+              <button class="btn btn-info" type="submit">{{ "SEARCH"|t }}</button>
+            </span>
+            </div>
           </div>
-        </div>
-      </form>
+        </form>
+      {% endif %}
+
       {% if ccc_logged_in %}
         {{ ccc_logged_menu }}
       {% elseif not ccc_logged_in and logged_in %}


### PR DESCRIPTION
https://fivejars.atlassian.net/browse/OYS-59

## Steps for review

- [ ]  login ad admin.
- [ ] open Appearance and click Set as default for Open Y Lily theme
- [ ]  open home page and make sure that search field is missing in header and mobile menu
- [ ]  open Extend admin menu or /admin/modules/.
- [ ]  enable module Open Y Google Search
- [ ]  return to home page.
- [ ]  make sure that appeared Search form in page header, it expanded on click and redirects to /search page
- [ ]  switch to mobile screen and open mobile menu using sandwich button
- [ ]  make sure that Search form appeared in mobile menu
- [ ]  open page /admin/appearance/settings/openy_lily
- [ ] make sure you see Display the search form setting with checkbox enabled
- [ ]  uncheck it and return to home page
- [ ]  make sure that Search field disappeared from desktop and mobile version

## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/ci-errors.png" width="200" alt="CI code sniffer errors">
- [ ] All tests are running and there are no failed tests reported by CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/behat.png" width="200" alt="Behat test results">
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
