### PR TITLE
[OYS-61] Carnation: Search field in website header

### DIFF
--- a/modules/custom/openy_search/openy_google_search/openy_google_search.info.yml
+++ b/modules/custom/openy_search/openy_google_search/openy_google_search.info.yml
@@ -4,3 +4,5 @@ description: Provides a Google Custom search Engine for Open Y.
 core: 8.x
 package: Open Y
 version: 8.x-1.0
+dependencies:
+  - openy_search

--- a/modules/custom/openy_search/openy_google_search/openy_google_search.install
+++ b/modules/custom/openy_search/openy_google_search/openy_google_search.install
@@ -4,18 +4,3 @@
  * @file
  * Module installation file.
  */
-
-/**
- * Implements hook_install().
- */
-function openy_google_search_install() {
-  /** @var \Drupal\Core\Config\ConfigFactoryInterface $config_factory */
-  $config_factory = \Drupal::configFactory();
-  $themes_list = [
-    'openy_rose',
-    'openy_carnation'
-  ];
-  foreach ($themes_list as $theme) {
-    $config_factory->getEditable($theme . '.settings')->set('display_search_form', '1')->save();
-  }
-}

--- a/modules/custom/openy_search/openy_search.info.yml
+++ b/modules/custom/openy_search/openy_search.info.yml
@@ -1,0 +1,6 @@
+name: Open Y Search
+type: module
+description: Provides a classes and services for search modules in Open Y.
+core: 8.x
+package: Open Y
+version: 8.x-1.0

--- a/modules/custom/openy_search/openy_search.services.yml
+++ b/modules/custom/openy_search/openy_search.services.yml
@@ -1,0 +1,6 @@
+services:
+  openy_search.overrider:
+    class: Drupal\openy_search\Config\OpenySearchOverrides
+    tags:
+      - {name: config.factory.override, priority: 5}
+    arguments: ['@config.factory']

--- a/modules/custom/openy_search/src/Config/OpenySearchOverrides.php
+++ b/modules/custom/openy_search/src/Config/OpenySearchOverrides.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Drupal\openy_search\Config;
+
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Config\ConfigFactory;
+use Drupal\Core\Config\ConfigFactoryOverrideInterface;
+use Drupal\Core\Config\StorageInterface;
+
+/**
+ * OpenY Search configuration override.
+ */
+class OpenySearchOverrides implements ConfigFactoryOverrideInterface {
+
+  /**
+   * Configuration factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactory
+   */
+  private $configFactory;
+
+  /**
+   * Constructs a DomainConfigSubscriber object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactory $config_factory
+   *   Configuration factory.
+   */
+  public function __construct(ConfigFactory $config_factory) {
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function loadOverrides($names) {
+    $default_theme = $this->configFactory->getEditable('system.theme')->getOriginal('default');
+    $overrides = [];
+    $moduleHandler = \Drupal::service('module_handler');
+    if ($moduleHandler->moduleExists('openy_google_search')) {
+      if (in_array($default_theme . '.settings', $names)) {
+        $overrides[$default_theme . '.settings'] = [
+          'search_query_key' => 'q',
+          'display_search_form' => 1,
+        ];
+      }
+    }
+    return $overrides;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheSuffix() {
+    return 'GoogleSearchOverrider';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheableMetadata($name) {
+    return new CacheableMetadata();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createConfigObject($name, $collection = StorageInterface::DEFAULT_COLLECTION) {
+    return NULL;
+  }
+
+}

--- a/openy.install
+++ b/openy.install
@@ -1015,7 +1015,7 @@ function openy_update_8069() {
     $config_importer->update($config, 'openy_carnation.settings', 'display_search_form');
   }
 }
- 
+
  /**
  * Import config with T&C.
  */
@@ -1054,5 +1054,23 @@ function openy_update_8076() {
     \Drupal::service('module_installer')->install([
       $module,
     ]);
+  }
+}
+
+/**
+ * Update themes settings: add search form query key.
+ */
+function openy_update_8077() {
+  $themes_list = [
+    'openy_lily',
+    'openy_carnation'
+  ];
+  foreach ($themes_list as $theme) {
+    if (\Drupal::service('theme_handler')->themeExists($theme)) {
+      $config = drupal_get_path('theme', $theme) . '/config/install/' . $theme . '.settings.yml';
+      /** @var Drupal\openy_upgrade_tool\ConfigParamUpgradeTool $config_importer */
+      $config_importer = \Drupal::service('openy_upgrade_tool.param_updater');
+      $config_importer->update($config, $theme . '.settings', 'search_query_key');
+    }
   }
 }

--- a/themes/openy_themes/openy_carnation/config/install/openy_carnation.settings.yml
+++ b/themes/openy_themes/openy_carnation/config/install/openy_carnation.settings.yml
@@ -14,5 +14,6 @@ openy_carnation_camp_favicon: {  }
 schemas:
   openy_carnation: 8000
 display_search_form: 1
+search_query_key: keys
 colored_logo: {  }
 matchheight_css_classes: ".viewport .page-head__main-menu .nav-level-3 > a\r\n.blog-up\r\n.blog-heading\r\n.inner-wrapper\r\n.card\r\n.card-body\r\n.card h3\r\n.card .node__content\r\n.block-description--text > h2\r\n.block-description--text > div\r\n.table-class"

--- a/themes/openy_themes/openy_carnation/openy_carnation.theme
+++ b/themes/openy_themes/openy_carnation/openy_carnation.theme
@@ -198,6 +198,7 @@ function openy_carnation_preprocess_menu(&$variables) {
   $variables['menu_name'] = isset($variables['menu_name']) ? $variables['menu_name'] : "";
   if ($variables['menu_name'] === 'main') {
     $variables['display_search'] = theme_get_setting('display_search_form');
+    $variables['search_key'] = theme_get_setting('search_query_key');
   }
 }
 
@@ -221,6 +222,7 @@ function openy_carnation_set_theme_file_usage(FileInterface $file) {
  */
 function openy_carnation_preprocess_page(array &$variables) {
   $variables['display_search'] = theme_get_setting('display_search_form');
+  $variables['search_key'] = theme_get_setting('search_query_key');
   $variables['base_path'] = \Drupal::request()->getSchemeAndHttpHost();
   $variables['site_slogan'] = \Drupal::config('system.site')->get('slogan');
   $variables['#attached']['drupalSettings']['matchheight']['selectors'] = load_matchheight_selectors();

--- a/themes/openy_themes/openy_carnation/templates/page/page.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/page/page.html.twig
@@ -80,9 +80,9 @@
 
         {% if display_search %}
           <div class="search-form-wrapper col-12 border-top border-bottom">
-            <form method="get" action="{{ base_path }}/search/node">
+            <form method="get" action="{{ base_path }}/search">
               <i class="fa fa-search search-input-decoration" aria-hidden="true"></i>
-              <input type="search" name="keys" class="search-input" placeholder="Search">
+              <input type="search" name="{{ search_key }}" class="search-input" placeholder="{{ 'Search'|t }}">
               <input type="submit" type="submit" value="Search">
             </form>
           </div>
@@ -127,9 +127,9 @@
                       <button class="navbar-toggler page-head__search-close text-white" type="button" data-toggle="collapse" data-target=".page-head__search" aria-controls="page-head__search" aria-expanded="false" aria-label="Hide search bar">
                         <i class="fa fa-times" aria-hidden="true"></i>
                       </button>
-                      <form method="get" action="{{ base_path }}/search/node">
+                      <form method="get" action="{{ base_path }}/search">
                         <i class="fa fa-search search-input-decoration" aria-hidden="true"></i>
-                        <input type="search" name="keys" class="search-input" placeholder="Search">
+                        <input type="search" name="{{ search_key }}" class="search-input" placeholder="{{ 'Search'|t }}">
                         <input type="submit" value="Search">
                       </form>
                     </div>

--- a/themes/openy_themes/openy_carnation/templates/paragraph/paragraph--banner.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/paragraph/paragraph--banner.html.twig
@@ -49,7 +49,7 @@
 
 <div{{ attributes.addClass(classes) }} {% if color is not empty %} style="background-color: {{ color }}" {% endif %}>
 
-  {% if paragraph.field_prgf_image|render|trim is not empty %}
+  {% if paragraph.field_prgf_image is not empty %}
     <div class="banner-bg" style="background: url('{{ file_url(paragraph.field_prgf_image.entity.field_media_image.entity.uri.value) }}') center center; background-size: cover;">
       <span></span>
     </div>

--- a/themes/openy_themes/openy_carnation/templates/paragraph/paragraph--small-banner.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/paragraph/paragraph--small-banner.html.twig
@@ -49,7 +49,7 @@
 
 <div{{ attributes.addClass(classes) }} {% if color is not empty %} style="background-color: {{ color }}" {% endif %}>
 
-  {% if paragraph.field_prgf_image|render|trim is not empty %}
+  {% if paragraph.field_prgf_image is not empty %}
     <div class="banner-bg" style="background: url('{{ file_url(paragraph.field_prgf_image.entity.field_media_image.entity.uri.value) }}') center center; background-size: cover;">
       <span></span>
     </div>


### PR DESCRIPTION
https://fivejars.atlassian.net/browse/OYS-61

## Steps for review

- [x]  login ad admin.
- [x]  open Appearance and click Set as default for Open Y Carnation theme
- [x] visit page admin/appearance/settings/openy_carnation
- [x] make sure that Display the search form checkbox present
- [x] uncheck it if it enabled
- [x]  open home page and make sure that search field is missing in header and mobile menu
- [x]  open Extend admin menu or /admin/modules/.
- [x]  enable module Open Y Google Search
- [x]  return to home page.
- [ ]  make sure that appeared Search form in page header, it expanded on click and redirects to /search page and "q" parameter in query used (search page not available in this PR)
- [ ]  switch to mobile screen and open mobile menu using sandwich button
- [ ]  make sure that Search form appeared in mobile menu
- [ ] visit admin/modules/uninstall
- [ ] uninstall module Open Y Google Search
- [ ] return to home page
- [ ] make sure that search still available in header
- [ ] type any term and cllck search, 
= [ ] make sure it redirects to page /search  with "keys" parameter in query 


