### PR TITLE
[OYS-60] Add search form to OpenY Rose theme using theme setting

### DIFF
--- a/modules/custom/openy_search/openy_google_search/openy_google_search.install
+++ b/modules/custom/openy_search/openy_google_search/openy_google_search.install
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @file
+ * Module installation file.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function openy_google_search_install() {
+  /** @var \Drupal\Core\Config\ConfigFactoryInterface $config_factory */
+  $config_factory = \Drupal::configFactory();
+  $themes_list = [
+    'openy_rose',
+    'openy_carnation'
+  ];
+  foreach ($themes_list as $theme) {
+    $config_factory->getEditable($theme . '.settings')->set('display_search_form', '1')->save();
+  }
+}

--- a/modules/custom/openy_search/openy_google_search/openy_google_search.module
+++ b/modules/custom/openy_search/openy_google_search/openy_google_search.module
@@ -13,19 +13,3 @@ function openy_google_search_theme($existing, $type, $theme, $path) {
     'openy_google_search' => [],
   ];
 }
-
-/**
- * Implements hook_preprocess_page().
- */
-function openy_google_search_preprocess_page(&$variables) {
-  // Enable search form on page when module enabled.
-  $variables['display_search'] = TRUE;
-}
-
-/**
- * Implements hook_preprocess_menu().
- */
-function openy_google_search_preprocess_menu__account(&$variables) {
-  // Enable search form in account menu when module enabled.
-  $variables['display_search'] = TRUE;
-}

--- a/themes/openy_themes/openy_rose/config/install/openy_rose.settings.yml
+++ b/themes/openy_themes/openy_rose/config/install/openy_rose.settings.yml
@@ -6,6 +6,7 @@ openy_rose_image_fields:
   camp_favicon: openy_rose_camp_favicon
 css_enabled: 1
 css: ""
+display_search_form: 1
 plaintext_enabled: 0
 autopreview_enabled: 0
 preview_path: ''

--- a/themes/openy_themes/openy_rose/openy_rose.theme
+++ b/themes/openy_themes/openy_rose/openy_rose.theme
@@ -179,6 +179,19 @@ function openy_rose_form_system_theme_settings_alter(array &$form, FormStateInte
     return;
   }
 
+  $form['search'] = [
+    '#type' => 'details',
+    '#title' => t('Search'),
+    '#open' => TRUE,
+  ];
+
+  $form['search']['display_search_form'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Display the search form'),
+    '#default_value' => theme_get_setting('display_search_form'),
+    '#description' => t('Show search form in the header'),
+  ];
+
   $form['logo']['openy_rose_footer_logo'] = array(
     '#type' => 'managed_file',
     '#title' => t('Footer Logo'),
@@ -321,11 +334,11 @@ function openy_rose_preprocess_page(array &$variables) {
       }
     }
   }
-
+  $variables['display_search'] = theme_get_setting('display_search_form');
   $variables['page']['secondary_menu']['search'] = [
     '#theme' => 'top_menu_search',
     '#base_path' => base_path(),
-    '#display_search' => $variables['display_search'] ?? FALSE,
+    '#display_search' => $variables['display_search'],
   ];
 }
 

--- a/themes/openy_themes/openy_rose/templates/page/page--header.html.html.twig
+++ b/themes/openy_themes/openy_rose/templates/page/page--header.html.html.twig
@@ -109,7 +109,7 @@
                     {{ page.search }}
                     <form method="get" action="{{ base_path }}search">
                       <i class="fa fa-search search-input-decoration" aria-hidden="true"></i>
-                      <input type="search" name="query" class="search-input" placeholder="Search">
+                      <input type="search" name="query" class="search-input" placeholder="{{ 'Search'|t }}">
                       <input type="submit" value="Search">
                     </form>
                     <a href="#" data-target=".page-head__search" data-toggle="collapse" class="page-head__search-close">


### PR DESCRIPTION
https://fivejars.atlassian.net/browse/OYS-60.

## Steps for review
- [ ] login as admin
- [ ] open page /admin/appearance/settings/openy_rose
- [ ] make sure you see Display the search form setting
- [ ] enable it and return to home page
- [ ] make sure that Search field appeared
- [ ] return to /admin/appearance/settings/openy_rose and uncheck Display the search form setting
- [ ] return to home page
- [ ] make sure Search field not displayed
- [ ] open Extend admin menu or /admin/modules/.
- [ ]  enable module Open Y Google Search
- [ ]  return to home page
- [ ] make sure that Search field appeared
- [ ] open page /admin/appearance/settings/openy_rose
- [ ] make sure that checkbox for Display the search form enabled

