### PR TITLE
[OYS-57] Search module fixes

### DIFF
--- a/modules/custom/openy_search/openy_google_search/openy_google_search.info.yml
+++ b/modules/custom/openy_search/openy_google_search/openy_google_search.info.yml
@@ -4,5 +4,6 @@ description: Provides a Google Custom search Engine for Open Y.
 core: 8.x
 package: Open Y
 version: 8.x-1.0
+configure: openy_google_search.settings
 dependencies:
   - openy_search

--- a/modules/custom/openy_search/openy_google_search/src/Form/SettingsForm.php
+++ b/modules/custom/openy_search/openy_google_search/src/Form/SettingsForm.php
@@ -37,6 +37,7 @@ class SettingsForm extends ConfigFormBase {
       '#title' => $this->t('Google Search Engine ID'),
       '#size' => 40,
       '#default_value' => !empty($config->get('google_engine_id')) ? $config->get('google_engine_id') : '',
+      '#required' => TRUE,
     ];
 
     return parent::buildForm($form, $form_state);

--- a/modules/custom/openy_search/openy_search.services.yml
+++ b/modules/custom/openy_search/openy_search.services.yml
@@ -3,4 +3,4 @@ services:
     class: Drupal\openy_search\Config\OpenySearchOverrides
     tags:
       - {name: config.factory.override, priority: 5}
-    arguments: ['@config.factory']
+    arguments: ['@config.factory', '@module_handler']

--- a/modules/custom/openy_search/src/Config/OpenySearchOverrides.php
+++ b/modules/custom/openy_search/src/Config/OpenySearchOverrides.php
@@ -6,6 +6,7 @@ use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Config\ConfigFactory;
 use Drupal\Core\Config\ConfigFactoryOverrideInterface;
 use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
 
 /**
  * OpenY Search configuration override.
@@ -20,13 +21,23 @@ class OpenySearchOverrides implements ConfigFactoryOverrideInterface {
   private $configFactory;
 
   /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  private $moduleHandler;
+
+  /**
    * Constructs a DomainConfigSubscriber object.
    *
    * @param \Drupal\Core\Config\ConfigFactory $config_factory
    *   Configuration factory.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   Module handler.
    */
-  public function __construct(ConfigFactory $config_factory) {
+  public function __construct(ConfigFactory $config_factory, ModuleHandlerInterface $module_handler) {
     $this->configFactory = $config_factory;
+    $this->moduleHandler = $module_handler;
   }
 
   /**
@@ -35,8 +46,7 @@ class OpenySearchOverrides implements ConfigFactoryOverrideInterface {
   public function loadOverrides($names) {
     $default_theme = $this->configFactory->getEditable('system.theme')->getOriginal('default');
     $overrides = [];
-    $moduleHandler = \Drupal::service('module_handler');
-    if ($moduleHandler->moduleExists('openy_google_search')) {
+    if ($this->moduleHandler->moduleExists('openy_google_search')) {
       if (in_array($default_theme . '.settings', $names)) {
         $overrides[$default_theme . '.settings'] = [
           'search_query_key' => 'q',


### PR DESCRIPTION
https://fivejars.atlassian.net/browse/OYS-57

## Steps for review

- [x] login as admin
- [x] visit admin/modules.
- [x] locate OpenY Google Search module and make sure configure link is present.
- [x] click link and make sure that google id field is required


