### PR TITLE
Don't display the search form by default for Lily and Rose.

### DIFF
--- a/themes/openy_themes/openy_lily/config/install/openy_lily.settings.yml
+++ b/themes/openy_themes/openy_lily/config/install/openy_lily.settings.yml
@@ -15,7 +15,7 @@ openy_lily_image_fields:
   camp_favicon: openy_lily_camp_favicon
 css_enabled: 1
 css: ""
-display_search_form: 1
+display_search_form: 0
 search_query_key: search
 search_page_alias: search
 plaintext_enabled: 0

--- a/themes/openy_themes/openy_rose/config/install/openy_rose.settings.yml
+++ b/themes/openy_themes/openy_rose/config/install/openy_rose.settings.yml
@@ -6,7 +6,7 @@ openy_rose_image_fields:
   camp_favicon: openy_rose_camp_favicon
 css_enabled: 1
 css: ""
-display_search_form: 1
+display_search_form: 0
 search_query_key: q
 search_page_alias: search
 plaintext_enabled: 0


### PR DESCRIPTION
## Steps for review

- [ ] Install the Standart version of Open Y with Rose theme.
- [ ] Verify the search form is not displayed in the header.
- [ ] Enable the Lily theme.
- [ ] Verify the same.

