### PR TITLE
Invalidate config cache

### DIFF
--- a/modules/custom/openy_search/openy_google_search/openy_google_search.module
+++ b/modules/custom/openy_search/openy_google_search/openy_google_search.module
@@ -35,12 +35,16 @@ function openy_google_search_entity_view_alter(&$build, EntityInterface $entity,
   $config = \Drupal::config('openy_google_search.settings');
   $engine_id = $config->get('google_engine_id');
   if (empty($engine_id)) {
+    $url = Url::fromRoute('openy_google_search.settings');
     $args = [
-      ':search_settings' => Url::fromRoute('openy_google_search.settings')->toString(),
+      ':search_settings' => $url->toString(),
     ];
     $message = t('Please set ENGINE_ID at the <a href=":search_settings">search settings page</a> in order to use Google Search.', $args);
-    \Drupal::messenger()->addError($message);
+
     return [
+      '#type' => 'html_tag',
+      '#tag' => 'p',
+      '#value' => $message,
       '#cache' => [
         'tags' => $config->getCacheTags(),
       ],

--- a/modules/custom/openy_search/openy_google_search/openy_google_search.module
+++ b/modules/custom/openy_search/openy_google_search/openy_google_search.module
@@ -41,7 +41,7 @@ function openy_google_search_entity_view_alter(&$build, EntityInterface $entity,
     ];
     $message = t('Please set ENGINE_ID at the <a href=":search_settings">search settings page</a> in order to use Google Search.', $args);
 
-    $build = [
+    $build['message'] = [
       '#type' => 'html_tag',
       '#tag' => 'p',
       '#value' => $message,

--- a/modules/custom/openy_search/openy_google_search/openy_google_search.module
+++ b/modules/custom/openy_search/openy_google_search/openy_google_search.module
@@ -41,7 +41,7 @@ function openy_google_search_entity_view_alter(&$build, EntityInterface $entity,
     ];
     $message = t('Please set ENGINE_ID at the <a href=":search_settings">search settings page</a> in order to use Google Search.', $args);
 
-    return [
+    $build = [
       '#type' => 'html_tag',
       '#tag' => 'p',
       '#value' => $message,
@@ -49,6 +49,8 @@ function openy_google_search_entity_view_alter(&$build, EntityInterface $entity,
         'tags' => $config->getCacheTags(),
       ],
     ];
+
+    return $build;
   }
 
   $build['google_search'] = [

--- a/modules/custom/openy_search/openy_google_search/openy_google_search.module
+++ b/modules/custom/openy_search/openy_google_search/openy_google_search.module
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Url;
 
 /**
  * Implements hook_theme().
@@ -31,18 +32,25 @@ function openy_google_search_entity_view_alter(&$build, EntityInterface $entity,
   if ($entity->bundle() != 'google_search') {
     return;
   }
-  $engine_id = \Drupal::config('openy_google_search.settings')->get('google_engine_id');
+  $config = \Drupal::config('openy_google_search.settings');
+  $engine_id = $config->get('google_engine_id');
   if (empty($engine_id)) {
-    \Drupal::messenger()
-      ->addError('Please set ENGINE_ID in the search settings.');
-    return;
+    $args = [
+      ':search_settings' => Url::fromRoute('openy_google_search.settings')->toString(),
+    ];
+    $message = t('Please set ENGINE_ID at the <a href=":search_settings">search settings page</a> in order to use Google Search.', $args);
+    \Drupal::messenger()->addError($message);
+    return [
+      '#cache' => [
+        'tags' => $config->getCacheTags(),
+      ],
+    ];
   }
 
   $build['google_search'] = [
     '#theme' => 'openy_google_search',
     '#cache' => [
-      'max-age' => -1,
-      'tags' => ['config:openy_google_search.settings'],
+      'tags' => $config->getCacheTags(),
     ],
     '#attached' => [
       'library' => ['openy_google_search/google_search'],

--- a/modules/custom/openy_search/openy_google_search/src/Form/SettingsForm.php
+++ b/modules/custom/openy_search/openy_google_search/src/Form/SettingsForm.php
@@ -2,13 +2,46 @@
 
 namespace Drupal\openy_google_search\Form;
 
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Settings Form for openy_google_search.
  */
 class SettingsForm extends ConfigFormBase {
+
+  /**
+   * The cache tags invalidator.
+   *
+   * @var \Drupal\Core\Cache\CacheTagsInvalidatorInterface
+   */
+  protected $cacheTagsInvalidator;
+
+  /**
+   * Constructs a \Drupal\openy_google_search\Form\SettingsForm object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
+   * @param \Drupal\Core\Cache\CacheTagsInvalidatorInterface $cache_tags_invalidator
+   *   The cache tag invalidator.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, CacheTagsInvalidatorInterface $cache_tags_invalidator) {
+    $this->setConfigFactory($config_factory);
+    $this->cacheTagsInvalidator = $cache_tags_invalidator;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('cache_tags.invalidator')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -51,6 +84,8 @@ class SettingsForm extends ConfigFormBase {
     $config = $this->config('openy_google_search.settings');
     $config->set('google_engine_id', $values['google_engine_id']);
     $config->save();
+
+    $this->cacheTagsInvalidator->invalidateTags($config->getCacheTags());
 
     parent::submitForm($form, $form_state);
   }

--- a/modules/custom/openy_search/openy_google_search/templates/openy-google-search.html.twig
+++ b/modules/custom/openy_search/openy_google_search/templates/openy-google-search.html.twig
@@ -1,1 +1,2 @@
-<div class="gcse-searchresults-only" data-queryparametername="q"></div>
+<div class="gcse-searchbox-only" data-gname="searchs" data-resultsurl="/search" data-newwindow="false" data-queryparametername="q"></div>
+<div class="gcse-searchresults-only" data-gname="searchr" data-queryparametername="q" data-newwindow="false" data-autosearchonload="true" data-enableimagesearch="false"></div>


### PR DESCRIPTION
## Steps for review

- [ ] install the Search package but do not configure Google Search
- [ ] use the search
- [ ] verify it leaves the warning message with a link to the Configuration page
- [ ] refresh the page
- [ ] verify it still shows the warning
- [ ] go to the configuration page and specify the Search Engine ID
- [ ] use the search again
- [ ] verify it works