### PR TITLE
[OYS-90] Add hook to alter search parameters in theme.

### DIFF
--- a/modules/custom/openy_search/openy_google_search/config/install/openy_google_search.settings.yml
+++ b/modules/custom/openy_search/openy_google_search/config/install/openy_google_search.settings.yml
@@ -1,4 +1,3 @@
 google_engine_id: ''
-search_page_alias: 'search'
 search_page_id: ''
 search_query_key: 'q'

--- a/modules/custom/openy_search/openy_google_search/openy_google_search.install
+++ b/modules/custom/openy_search/openy_google_search/openy_google_search.install
@@ -12,7 +12,6 @@ use Drupal\node\NodeInterface;
  */
 function openy_google_search_install() {
   // Create search results page for google custom search.
-  $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
   $entity_type_manager = \Drupal::entityTypeManager();
   $paragraph_storage = $entity_type_manager->getStorage('paragraph');
   $node_storage = $entity_type_manager->getStorage('node');
@@ -39,11 +38,9 @@ function openy_google_search_install() {
     'status' => NodeInterface::PUBLISHED,
   ]);
   if ($page->save()) {
-    $alias = ltrim(Drupal::service('path.alias_manager')->getAliasByPath('/node/' . $page->id(), $langcode), '/');
     Drupal::configFactory()
       ->getEditable('openy_google_search.settings')
       ->set('search_page_id', $page->id())
-      ->set('search_page_alias', $alias)
       ->save();
   }
   drupal_flush_all_caches();

--- a/modules/custom/openy_search/openy_google_search/openy_google_search.install
+++ b/modules/custom/openy_search/openy_google_search/openy_google_search.install
@@ -6,20 +6,13 @@
  */
 
 use Drupal\node\NodeInterface;
-use Drupal\pathauto\PathautoState;
 
 /**
  * Implements hook_install().
  */
 function openy_google_search_install() {
-
-  $alias = '/search';
-  /** @var \Drupal\Core\Path\AliasStorageInterface $path_alias_storage */
-  $path_alias_storage = \Drupal::service('path.alias_storage');
-  $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
-  if ($path_alias_storage->aliasExists($alias, $language)) {
-    return;
-  }
+  // Create search results page for google custom search.
+  $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
   $entity_type_manager = \Drupal::entityTypeManager();
   $paragraph_storage = $entity_type_manager->getStorage('paragraph');
   $node_storage = $entity_type_manager->getStorage('node');
@@ -33,7 +26,7 @@ function openy_google_search_install() {
 
   $page = $node_storage->create([
     'type' => 'landing_page',
-    'title' => 'Search results',
+    'title' => 'Search',
     'field_lp_layout' => 'one_column',
     'langcode' => 'en',
     'uid' => '1',
@@ -44,15 +37,13 @@ function openy_google_search_install() {
       ],
     ],
     'status' => NodeInterface::PUBLISHED,
-    'path' => [
-      'pathauto' => PathautoState::SKIP,
-      'alias' => $alias,
-    ],
   ]);
   if ($page->save()) {
-    \Drupal::configFactory()
+    $alias = ltrim(Drupal::service('path.alias_manager')->getAliasByPath('/node/' . $page->id(), $langcode), '/');
+    Drupal::configFactory()
       ->getEditable('openy_google_search.settings')
       ->set('search_page_id', $page->id())
+      ->set('search_page_alias', $alias)
       ->save();
   }
   drupal_flush_all_caches();
@@ -62,7 +53,7 @@ function openy_google_search_install() {
  * Implements hook_uninstall().
  */
 function openy_google_search_uninstall() {
-  if ($nid = \Drupal::configFactory()
+  if ($nid = Drupal::configFactory()
     ->get('openy_google_search.settings')
     ->get('search_page_id')) {
     $node_storage = \Drupal::entityTypeManager()->getStorage('node');

--- a/modules/custom/openy_search/openy_google_search/openy_google_search.module
+++ b/modules/custom/openy_search/openy_google_search/openy_google_search.module
@@ -80,10 +80,11 @@ function openy_google_search_help($route_name, RouteMatchInterface $route_match)
 /**
  * Implements hook_openy_search_configuration_overrides_alter().
  */
-function openy_google_search_openy_search_configuration_overrides_alter(&$overrides) {
+function openy_google_search_openy_search_theme_configuration_alter(&$overrides) {
+  $search_config = \Drupal::configFactory()->get('openy_google_search.settings');
   $overrides = [
-    'search_query_key' => 'q',
-    'search_page_alias' => 'search',
+    'search_query_key' => $search_config->get('search_query_key'),
+    'search_page_alias' => $search_config->get('search_page_alias'),
     'display_search_form' => 1,
   ];
 }

--- a/modules/custom/openy_search/openy_google_search/openy_google_search.module
+++ b/modules/custom/openy_search/openy_google_search/openy_google_search.module
@@ -82,9 +82,13 @@ function openy_google_search_help($route_name, RouteMatchInterface $route_match)
  */
 function openy_google_search_openy_search_theme_configuration_alter(&$overrides) {
   $search_config = \Drupal::configFactory()->get('openy_google_search.settings');
+  $search_page_id = $search_config->get('search_page_id');
+  $langcode = Drupal::languageManager()->getCurrentLanguage()->getId();
+  $alias = ltrim(Drupal::service('path.alias_manager')->getAliasByPath('/node/' . $search_page_id, $langcode), '/');
+
   $overrides = [
     'search_query_key' => $search_config->get('search_query_key'),
-    'search_page_alias' => $search_config->get('search_page_alias'),
+    'search_page_alias' => $alias,
     'display_search_form' => 1,
   ];
 }

--- a/modules/custom/openy_search/openy_google_search/openy_google_search.module
+++ b/modules/custom/openy_search/openy_google_search/openy_google_search.module
@@ -76,3 +76,14 @@ function openy_google_search_help($route_name, RouteMatchInterface $route_match)
     return '<p>' . t('Read <a href="https://github.com/ymcatwincities/openy/blob/8.x-2.x/docs/Development/GoogleCustomSearchConfiguration.md">this topic</a> in Open Y online documentation to get information about Google Custom Search configuration.') . '</p>';
   }
 }
+
+/**
+ * Implements hook_openy_search_configuration_overrides_alter().
+ */
+function openy_google_search_openy_search_configuration_overrides_alter(&$overrides) {
+  $overrides = [
+    'search_query_key' => 'q',
+    'search_page_alias' => 'search',
+    'display_search_form' => 1,
+  ];
+}

--- a/modules/custom/openy_search/openy_search.api.php
+++ b/modules/custom/openy_search/openy_search.api.php
@@ -15,7 +15,7 @@
  *
  * @see \Drupal\openy_search\Config\OpenySearchOverrides::loadOverrides()
  */
-function hook_openy_search_configuration_overrides_alter(&$search_config) {
+function hook_openy_search_theme_configuration_alter(&$search_config) {
   $search_config = [
     'search_query_key' => 'q',
     'search_page_alias' => 'search',

--- a/modules/custom/openy_search/openy_search.api.php
+++ b/modules/custom/openy_search/openy_search.api.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * Hooks specific to the openy_search module.
+ */
+
+/**
+ * Alter the default Open Y themes search form parameters.
+ *
+ * Search parameters for theme originally stored in theme_name.settings file.
+ *
+ * @param array $search_config
+ *   The associative array of search form parameters.
+ *
+ * @see \Drupal\openy_search\Config\OpenySearchOverrides::loadOverrides()
+ */
+function hook_openy_search_configuration_overrides_alter(&$search_config) {
+  $search_config = [
+    'search_query_key' => 'q',
+    'search_page_alias' => 'search',
+    'display_search_form' => 1,
+  ];
+}

--- a/modules/custom/openy_search/openy_search_api/config/install/openy_search_api.settings.yml
+++ b/modules/custom/openy_search/openy_search_api/config/install/openy_search_api.settings.yml
@@ -1,3 +1,2 @@
-search_page_alias: 'search'
 search_page_id: ''
 search_query_key: 'query'

--- a/modules/custom/openy_search/openy_search_api/config/install/openy_search_api.settings.yml
+++ b/modules/custom/openy_search/openy_search_api/config/install/openy_search_api.settings.yml
@@ -1,4 +1,3 @@
-google_engine_id: ''
 search_page_alias: 'search'
 search_page_id: ''
-search_query_key: 'q'
+search_query_key: 'query'

--- a/modules/custom/openy_search/openy_search_api/openy_search_api.install
+++ b/modules/custom/openy_search/openy_search_api/openy_search_api.install
@@ -7,22 +7,14 @@
 
 use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
-use Drupal\pathauto\PathautoState;
 
 /**
  * Implements hook_install().
  */
 function openy_search_api_install() {
-
-  // Create search results page for defaule search api
-  $alias = '/search';
-  /** @var \Drupal\Core\Path\AliasStorageInterface $path_alias_storage */
-  $path_alias_storage = \Drupal::service('path.alias_storage');
-  $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
-  if ($path_alias_storage->aliasExists($alias, $language)) {
-    return;
-  }
-  $entity_type_manager = \Drupal::entityTypeManager();
+  // Create search results page for default search api.
+  $langcode = Drupal::languageManager()->getCurrentLanguage()->getId();
+  $entity_type_manager = Drupal::entityTypeManager();
   $paragraph_storage = $entity_type_manager->getStorage('paragraph');
   $node_storage = $entity_type_manager->getStorage('node');
 
@@ -46,22 +38,22 @@ function openy_search_api_install() {
       ],
     ],
     'status' => NodeInterface::PUBLISHED,
-    'path' => [
-      'alias' => $alias,
-    ],
   ]);
   if ($page->save()) {
-    \Drupal::configFactory()
+    $alias = ltrim(Drupal::service('path.alias_manager')->getAliasByPath('/node/' . $page->id(), $langcode), '/');
+    Drupal::configFactory()
       ->getEditable('openy_search_api.settings')
       ->set('search_page_id', $page->id())
+      ->set('search_page_alias', $alias)
       ->save();
   }
   drupal_flush_all_caches();
+  // Display message about search settings.
   $url = Url::fromRoute('search_api.overview');
   $args = [
     ':search_api_overview' => $url->toString(),
   ];
-  $messenger = \Drupal::messenger();
+  $messenger = Drupal::messenger();
   $messenger->addMessage(
     t('Please check your search_api <a href=":search_api_overview">search settings page</a>', $args),
     'status'
@@ -72,10 +64,10 @@ function openy_search_api_install() {
  * Implements hook_uninstall().
  */
 function openy_search_api_uninstall() {
-  if ($nid = \Drupal::configFactory()
+  if ($nid = Drupal::configFactory()
     ->get('openy_search_api.settings')
     ->get('search_page_id')) {
-    $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+    $node_storage = Drupal::entityTypeManager()->getStorage('node');
     if ($node = $node_storage->load($nid)) {
       $node->delete();
     }

--- a/modules/custom/openy_search/openy_search_api/openy_search_api.install
+++ b/modules/custom/openy_search/openy_search_api/openy_search_api.install
@@ -13,7 +13,6 @@ use Drupal\node\NodeInterface;
  */
 function openy_search_api_install() {
   // Create search results page for default search api.
-  $langcode = Drupal::languageManager()->getCurrentLanguage()->getId();
   $entity_type_manager = Drupal::entityTypeManager();
   $paragraph_storage = $entity_type_manager->getStorage('paragraph');
   $node_storage = $entity_type_manager->getStorage('node');
@@ -40,11 +39,9 @@ function openy_search_api_install() {
     'status' => NodeInterface::PUBLISHED,
   ]);
   if ($page->save()) {
-    $alias = ltrim(Drupal::service('path.alias_manager')->getAliasByPath('/node/' . $page->id(), $langcode), '/');
     Drupal::configFactory()
       ->getEditable('openy_search_api.settings')
       ->set('search_page_id', $page->id())
-      ->set('search_page_alias', $alias)
       ->save();
   }
   drupal_flush_all_caches();

--- a/modules/custom/openy_search/openy_search_api/openy_search_api.module
+++ b/modules/custom/openy_search/openy_search_api/openy_search_api.module
@@ -36,9 +36,13 @@ function openy_search_api_help($route_name, RouteMatchInterface $route_match) {
  */
 function openy_search_api_openy_search_theme_configuration_alter(&$overrides) {
   $search_config = \Drupal::configFactory()->get('openy_search_api.settings');
+  $search_page_id = $search_config->get('search_page_id');
+  $langcode = Drupal::languageManager()->getCurrentLanguage()->getId();
+  $alias = ltrim(Drupal::service('path.alias_manager')->getAliasByPath('/node/' . $search_page_id, $langcode), '/');
+
   $overrides = [
     'search_query_key' => $search_config->get('search_query_key'),
-    'search_page_alias' => $search_config->get('search_page_alias'),
+    'search_page_alias' => $alias,
     'display_search_form' => 1,
   ];
 }

--- a/modules/custom/openy_search/openy_search_api/openy_search_api.module
+++ b/modules/custom/openy_search/openy_search_api/openy_search_api.module
@@ -31,14 +31,14 @@ function openy_search_api_help($route_name, RouteMatchInterface $route_match) {
   }
 }
 
-
 /**
  * Implements hook_openy_search_configuration_overrides_alter().
  */
-function openy_search_api_openy_search_configuration_overrides_alter(&$overrides) {
+function openy_search_api_openy_search_theme_configuration_alter(&$overrides) {
+  $search_config = \Drupal::configFactory()->get('openy_search_api.settings');
   $overrides = [
-    'search_query_key' => 'query',
-    'search_page_alias' => 'search',
+    'search_query_key' => $search_config->get('search_query_key'),
+    'search_page_alias' => $search_config->get('search_page_alias'),
     'display_search_form' => 1,
   ];
 }

--- a/modules/custom/openy_search/openy_search_api/openy_search_api.module
+++ b/modules/custom/openy_search/openy_search_api/openy_search_api.module
@@ -30,3 +30,15 @@ function openy_search_api_help($route_name, RouteMatchInterface $route_match) {
     return '<p>' . t('Read <a href="https://www.drupal.org/docs/8/modules/search-api">Search API online documentation</a> at Drupal.org to get information about Search configuration.') . '</p>';
   }
 }
+
+
+/**
+ * Implements hook_openy_search_configuration_overrides_alter().
+ */
+function openy_search_api_openy_search_configuration_overrides_alter(&$overrides) {
+  $overrides = [
+    'search_query_key' => 'query',
+    'search_page_alias' => 'search',
+    'display_search_form' => 1,
+  ];
+}

--- a/modules/custom/openy_search/src/Config/OpenySearchOverrides.php
+++ b/modules/custom/openy_search/src/Config/OpenySearchOverrides.php
@@ -48,7 +48,7 @@ class OpenySearchOverrides implements ConfigFactoryOverrideInterface {
     $overrides = [];
     if (in_array($default_theme . '.settings', $names)) {
       // Allow other modules to alter the theme search configuration.
-      $this->moduleHandler->alter('openy_search_configuration_overrides', $overrides[$default_theme . '.settings']);
+      $this->moduleHandler->alter('openy_search_theme_configuration', $overrides[$default_theme . '.settings']);
     }
     return $overrides;
   }

--- a/modules/custom/openy_search/src/Config/OpenySearchOverrides.php
+++ b/modules/custom/openy_search/src/Config/OpenySearchOverrides.php
@@ -46,14 +46,9 @@ class OpenySearchOverrides implements ConfigFactoryOverrideInterface {
   public function loadOverrides($names) {
     $default_theme = $this->configFactory->getEditable('system.theme')->getOriginal('default');
     $overrides = [];
-    if ($this->moduleHandler->moduleExists('openy_google_search')) {
-      if (in_array($default_theme . '.settings', $names)) {
-        $overrides[$default_theme . '.settings'] = [
-          'search_query_key' => 'q',
-          'search_page_alias' => 'search',
-          'display_search_form' => 1,
-        ];
-      }
+    if (in_array($default_theme . '.settings', $names)) {
+      // Allow other modules to alter the theme search configuration.
+      $this->moduleHandler->alter('openy_search_configuration_overrides', $overrides[$default_theme . '.settings']);
     }
     return $overrides;
   }


### PR DESCRIPTION
Original Issue, this PR is going to fix: https://fivejars.atlassian.net/browse/OYS-90
Make sure these boxes are checked before asking for review of your pull request - thank you!

If there is a new feature or this is a bug fix - use 8.x-2.x branch. We'll tag for release if the bug is critical asap or tag for release next bug fix release until critical issue arrived.

## Steps for review

- [ ] login as admin
- [ ] make sure no search form in header
- [ ] visit admin/modules and enable Open Y Search API module (see steps from https://github.com/fivejars/openy/pull/61 to configure module and rerun index) 
- [ ] make sure search appeared in header and search works 
- [ ] visit admin/modules/uninstall and uninstall Open Y Search API module and 
- [ ] visit admin/modules and enable Open Y Google search
- [ ] Repeat steps from https://github.com/fivejars/openy/pull/26 to configure Google custom search
- [ ] make sure form displayed in header and search works
- [ ] visit admin/modules/uninstall and uninstall Open Y Google search module
- [ ] make sure search form missing in header
- [ ] go to Appearance page and switch to Carnation theme
- [ ] make sure that search form displayed in Carnation theme header by default

