### PR TITLE
[OYS-74]: Add notification about changes in Image entity browser configs.

### DIFF
--- a/modules/openy_features/openy_media/modules/openy_media_image/openy_media_image.install
+++ b/modules/openy_features/openy_media/modules/openy_media_image/openy_media_image.install
@@ -291,4 +291,12 @@ function openy_media_image_update_8012() {
     'entity_browser.browser.images_library_embed',
     'views.view.images_library',
   ]);
+
+  $message = "Image Library entity browser doesn't use 'images_library' view anymore. Custom changes may be lost.";
+  if (function_exists('drush_print')) {
+    drush_print(dt($message));
+  }
+  else {
+    \Drupal::messenger()->addMessage($message);
+  }
 }


### PR DESCRIPTION
## Steps for review

- [ ] Install any version of Open Y before `8.2.4.0`
- [ ] Run database updates with drush.
- [ ] Verify the message `Image Library entity browser doesn't use 'images_library' view anymore. Custom changes may be lost.` is printed.