### PR TITLE
[OYS-90] Fix header search form style for IE11 compatibility

### DIFF
--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -868,7 +868,7 @@ body {
 .header-search-wrapper {
   display: inline-block;
   vertical-align: top;
-  align-self: normal;
+  height: 3em;
   width: 200px;
 }
 .header-search-wrapper form {

--- a/themes/openy_themes/openy_rose/scss/modules/_header.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_header.scss
@@ -598,7 +598,7 @@
 .header-search-wrapper {
   display: inline-block;
   vertical-align: top;
-  align-self: normal;
+  height: 3em;
   width: 200px;
 
   form {


### PR DESCRIPTION

## Steps for review

- [ ] open default Open Rose theme home page in IE 11.
- [ ] make sure search form in header aligned with other menu items.
- [ ] compare it with Chrome.


## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
