### PR TITLE
[CR-22] Open Y Search API Solr upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -283,7 +283,7 @@
         "drupal/social_feed_fetcher": "^2.0",
         "symfony/dom-crawler": "~2.8|~3.0|~4.2",
         "mpdf/mpdf": "^7.1",
-        "drupal/search_api_solr": "1.3",
+        "drupal/search_api_solr": "^4.1",
         "drupal/search_api": "1.17",
         "npm-asset/blazy": "^1.8",
         "npm-asset/slick-carousel": "^1.8",

--- a/composer.json
+++ b/composer.json
@@ -196,6 +196,10 @@
             },
             "drupal/social_feed_fetcher": {
                 "Fix incorrect core key value in info file": "https://www.drupal.org/files/issues/2020-04-23/3130364-2.patch"
+            },
+            "drupal/search_api_solr": {
+                "Fix search_api_solr_cron() with Solr 4.x backend": "https://www.drupal.org/files/issues/2020-09-14/search_api_solr-solr_4_cron_fix-3170802.patch",
+                "Fix cores appear unavailable in UI with Solr 4.x backend": "https://www.drupal.org/files/issues/2020-09-14/search_api_solr-solr_4_core_unavailable_ui-3170793.patch"
             }
         }
     },

--- a/modules/custom/openy_activity_finder/config/optional/search_api.index.default.yml
+++ b/modules/custom/openy_activity_finder/config/optional/search_api.index.default.yml
@@ -2,23 +2,62 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.node.field_session_min_age
-    - field.storage.node.field_session_max_age
-    - field.storage.node.field_session_class
-    - field.storage.node.field_class_activity
     - field.storage.node.field_activity_category
-    - field.storage.node.field_session_location
     - field.storage.node.field_category_program
-    - field.storage.node.field_session_time
-    - field.storage.paragraph.field_session_time_days
+    - field.storage.node.field_class_activity
+    - field.storage.node.field_session_class
+    - field.storage.node.field_session_location
+    - field.storage.node.field_session_max_age
     - field.storage.node.field_session_mbr_price
+    - field.storage.node.field_session_min_age
     - field.storage.node.field_session_nmbr_price
+    - field.storage.node.field_session_time
     - field.storage.paragraph.field_session_time_date
+    - field.storage.paragraph.field_session_time_days
     - search_api.server.solr
   module:
+    - search_api_solr
     - node
     - paragraphs
     - search_api
+third_party_settings:
+  search_api_solr:
+    finalize: false
+    commit_before_finalize: false
+    commit_after_finalize: false
+    multilingual:
+      limit_to_content_language: false
+      include_language_independent: true
+    highlighter:
+      maxAnalyzedChars: 51200
+      fragmenter: gap
+      regex:
+        slop: 0.5
+        pattern: blank
+        maxAnalyzedChars: 10000
+      usePhraseHighlighter: true
+      highlightMultiTerm: true
+      preserveMulti: false
+      highlight:
+        mergeContiguous: false
+        requireFieldMatch: false
+        snippets: 3
+        fragsize: 0
+    mlt:
+      mintf: 1
+      mindf: 1
+      maxdf: 0
+      maxdfpct: 0
+      minwl: 0
+      maxwl: 0
+      maxqt: 100
+      maxntp: 2000
+      boost: false
+      interestingTerms: none
+    advanced:
+      index_prefix: ''
+      collection: ''
+      timezone: ''
 id: default
 name: Default
 description: ''
@@ -48,6 +87,7 @@ field_settings:
   af_parts_of_day:
     label: 'Parts of day'
     property_path: search_api_af_parts_of_day
+    type: string
   af_weeks:
     label: Weeks
     property_path: search_api_af_weeks
@@ -57,6 +97,9 @@ field_settings:
     datasource_id: 'entity:node'
     property_path: title
     type: text
+    dependencies:
+      module:
+        - node
   field_session_min_age:
     label: 'Min Age'
     datasource_id: 'entity:node'
@@ -80,6 +123,9 @@ field_settings:
     type: boolean
     indexed_locked: true
     type_locked: true
+    dependencies:
+      module:
+        - node
   uid:
     label: uid
     datasource_id: 'entity:node'
@@ -87,6 +133,9 @@ field_settings:
     type: integer
     indexed_locked: true
     type_locked: true
+    dependencies:
+      module:
+        - node
   field_activity_category:
     label: 'Program Subcategory'
     datasource_id: 'entity:node'
@@ -98,8 +147,6 @@ field_settings:
         - field.storage.node.field_class_activity
         - field.storage.node.field_activity_category
       module:
-        - node
-        - node
         - node
   field_session_location:
     label: Location
@@ -118,14 +165,11 @@ field_settings:
     type: string
     dependencies:
       config:
-        - field.storage.node.field_session_class
-        - field.storage.node.field_class_activity
         - field.storage.node.field_activity_category
         - field.storage.node.field_category_program
+        - field.storage.node.field_class_activity
+        - field.storage.node.field_session_class
       module:
-        - node
-        - node
-        - node
         - node
   field_session_time_days:
     label: Days
@@ -196,6 +240,8 @@ processor_settings:
   content_access:
     weights:
       preprocess_query: -30
+  language_with_fallback: {  }
+  solr_date_range: {  }
 tracker_settings:
   default:
     indexing_order: fifo

--- a/modules/custom/openy_activity_finder/config/optional/search_api.server.solr.yml
+++ b/modules/custom/openy_activity_finder/config/optional/search_api.server.solr.yml
@@ -13,19 +13,31 @@ backend_config:
     scheme: http
     host: solr
     port: '8983'
-    path: /solr
+    path: ''
     core: collection1
     timeout: 5
     index_timeout: 5
     optimize_timeout: 10
+    finalize_timeout: 30
     commit_within: 1000
     solr_version: ''
     http_method: AUTO
+    jmx: false
+    solr_install_dir: ''
+  disabled_field_types: {  }
+  disabled_caches: {  }
+  disabled_request_handlers:
+    - request_handler_elevate_default_7_0_0
+    - request_handler_replicationmaster_default_7_0_0
+    - request_handler_replicationslave_default_7_0_0
+  disabled_request_dispatchers:
+    - request_dispatcher_httpcaching_default_7_0_0
+  rows: 10
   retrieve_data: false
   highlight_data: false
-  excerpt: false
   skip_schema_check: false
+  server_prefix: ''
+  domain: generic
+  environment: default
+  optimize: false
   site_hash: true
-  suggest_suffix: true
-  suggest_corrections: true
-  suggest_words: false

--- a/modules/custom/openy_search/openy_search_api/config/install/search_api.server.solr_search.yml
+++ b/modules/custom/openy_search/openy_search_api/config/install/search_api.server.solr_search.yml
@@ -12,20 +12,33 @@ backend_config:
   connector_config:
     scheme: http
     host: solr
-    port: '8983'
-    path: /solr
+    port: 8983
+    path: ''
     core: collection1
     timeout: 5
     index_timeout: 5
     optimize_timeout: 10
+    finalize_timeout: 10
     commit_within: 1000
     solr_version: ''
     http_method: AUTO
+    jmx: false
+    solr_install_dir: ''
+    username: ''
+  disabled_field_types: { }
+  disabled_caches: { }
+  disabled_request_handlers:
+    - request_handler_elevate_default_7_0_0
+    - request_handler_replicationmaster_default_7_0_0
+    - request_handler_replicationslave_default_7_0_0
+  disabled_request_dispatchers:
+    - request_dispatcher_httpcaching_default_7_0_0
+  rows: 10
   retrieve_data: false
   highlight_data: false
-  excerpt: false
   skip_schema_check: false
+  server_prefix: ''
+  domain: generic
+  environment: default
+  optimize: false
   site_hash: true
-  suggest_suffix: true
-  suggest_corrections: true
-  suggest_words: true

--- a/modules/custom/openy_search/openy_search_api/openy_search_api.install
+++ b/modules/custom/openy_search/openy_search_api/openy_search_api.install
@@ -72,3 +72,35 @@ function openy_search_api_uninstall() {
     }
   }
 }
+
+/**
+ * Enable Search API Solr legacy if needed.
+ */
+function openy_search_api_update_8001() {
+  $messages = [];
+  if (openy_enable_search_api_solr_legacy()) {
+    $messages[] = '***';
+    $messages[] = '*** You are using a legacy version of Apache Solr. Enabling the Search API Solr Legacy module. ***';
+    $messages[] = '***';
+    $messages[] = '';
+  }
+  $messages[] = '* MAJOR SOLR SEARCH MODULE UPGRADE (1.x to 4.x).';
+  $messages[] = '*';
+  $messages[] = '* Download the updated Apache Solr configuration form the Search API module <a href="/admin/config/search/search-api">configuration page</a>.';
+  $messages[] = '** On the page, find each individual Search server, click its name and download the config.zip using "Get config.zip" button.';
+  $messages[] = '** Alternatively, use `drush solr-gsc YOUR_SEARCH_API_SERVER_ID` command.';
+  $messages[] = '** Alternatively, use a jump-start configuration from https://git.drupalcode.org/project/search_api_solr/-/tree/4.x/jump-start';
+  $messages[] = '* Apply the new Solr configuration. Ask your server administrator or a hosting support for assistance.';
+  $messages[] = '* Reindex the associated Search API indexes.';
+  $messages[] = '*';
+  $messages[] = '* For more details see https://www.drupal.org/docs/8/modules/search-api-solr/search-api-solr-howtos/migrate-from-8x-1x-to-4x';
+  $messages[] = '*';
+
+  $messenger = \Drupal::messenger();
+  foreach ($messages as $message) {
+    $messenger->addMessage($message, 'warning');
+    if (function_exists('drush_print')) {
+      drush_print($message);
+    }
+  }
+}

--- a/openy.profile
+++ b/openy.profile
@@ -279,6 +279,9 @@ function openy_install_search(array &$install_state) {
   foreach ($modules as $module) {
     $module_operations[] = ['openy_enable_module', (array) $module];
   }
+  // todo: install search_api_solr_legacy.
+  $module_operations[] = ['openy_enable_search_api_solr_legacy', []];
+
   return ['operations' => $module_operations];
 }
 
@@ -765,4 +768,41 @@ function openy_terms_and_condition_db_save(&$install_state) {
   $config->set('version', TermsOfUseForm::TERMS_OF_USE_VERSION);
   $config->set('accepted_version', time());
   $config->save();
+}
+
+/**
+ * Enables Search API Solr Legacy if Solr 4.x backend is detected.
+ *
+ * @return bool
+ *   TRUE if the legacy module was enabled.
+ */
+function openy_enable_search_api_solr_legacy() {
+  $moduleHandler = \Drupal::service('module_handler');
+  if (!$moduleHandler->moduleExists('search_api_solr')) {
+    return;
+  }
+  $storage = \Drupal::entityTypeManager()
+    ->getStorage('search_api_server');
+  $search_api_servers = $storage->getQuery()->execute();
+
+  foreach ($search_api_servers as $search_api_server_id) {
+    $search_api_server = $storage->load($search_api_server_id);
+    if ($search_api_server->getBackendId() !== 'search_api_solr') {
+      continue;
+    }
+    if (!$search_api_server->hasValidBackend()) {
+      continue;
+    }
+    $connector = $search_api_server->getBackend()->getSolrConnector();
+    $solr_version = $connector->getSolrVersion();
+    $solr_version_forced = $connector->getSolrVersion(TRUE);
+    if (preg_match('/[45]{1}\.[0-9]+\.[0-9]+/', $solr_version)
+      || preg_match('/[45]{1}\.[0-9]+\.[0-9]+/', $solr_version_forced)) {
+      // Solr 4.x or 5.x found, install the Search API Solr Legacy module.
+      \Drupal::service('module_installer')->install(['search_api_solr_legacy']);
+      return TRUE;
+    }
+  }
+
+  return FALSE;
 }

--- a/src/Form/SearchSolrForm.php
+++ b/src/Form/SearchSolrForm.php
@@ -32,7 +32,7 @@ class SearchSolrForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    $solr_server_config = $this->config('search_api.server.openy_solr_search');
+    $solr_server_config = $this->config('search_api.server.solr_search');
 
     $backend_config = $solr_server_config->get('backend_config');
     $solr_connector_options = [


### PR DESCRIPTION
Original Issue, this PR is going to fix: https://fivejars.atlassian.net/browse/CR-22

## Steps for review

### General checks
- [ ] verify composer checkouts `drupal/search_api_solr` 4.1.x and `solarium/solarium` 6.x
- [ ] verify the search_api_solr patches apply without issues

### Installing Open Y from scratch
- [ ] During installation enable Open Y Search API with Solr backend
- [ ] At the Configure Solr Search step, verify the configuration form contains correct default values:
  - [ ] Solr path - empty
  - [ ] Solr core - collection1
- [ ] Verify the installation process finishes well

### Enabling Solr search on the Open Y website
- [ ] go to any build where Open Y is installed, but the Open Y Solr Search is not installed yet
- [ ] login as admin
- [ ] enable Open Y Search API (and Search API Solr Legacy for fj builds)

### Updating Open Y with Solr search enabled
- [ ] Verify the update goes smoothly
- [ ] Verify there are instructions posted during the upgrade (for Drush)
- [ ] Verify there are messages that the Solr configuration is outdated (for FJ builds, this PR)
- [ ] Verify there are no messages that the Solr configuration is outdated (for FJ builds where the configuration is updated, see #126 )

