### PR TITLE
[YGO-195] FIx ampersand in the news teaser.

### DIFF
--- a/themes/openy_themes/openy_carnation/templates/node/news/node--news--teaser.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/node/news/node--news--teaser.html.twig
@@ -83,7 +83,7 @@
 {% endblock %}
 
 {% block description %}
-  {{ content.field_news_description|render|striptags }}
+  {{ content.field_news_description|render|striptags|raw }}
 {% endblock %}
 
 {% block link %}


### PR DESCRIPTION
This PR is going to fix bug with Ampersand(and other special chars) what are not rendered in the news teaser https://i.imgur.com/riqybt4.png

Steps for review:
- [ ] visit /news
- [ ] edit some news from list
- [ ] add some text with ampersand in first wor of description (f.e. Before & After program!) https://i.imgur.com/fMMlPxq.png -> save
- [ ] return to /news 
- [ ] make sure ampersand displayed correctly https://i.imgur.com/Te9Ea5U.png
