### PR TITLE
[CR-45] Change the header and footer background color to a required one

### DIFF
--- a/themes/openy_themes/openy_bouquet/css/styles.css
+++ b/themes/openy_themes/openy_bouquet/css/styles.css
@@ -1,3 +1,7 @@
+.bg-openy-bouquet-blue {
+  background-color: #0089d0;
+}
+
 .block-inline-blockimage img {
   width: 100%;
 }

--- a/themes/openy_themes/openy_bouquet/templates/layout/page.html.twig
+++ b/themes/openy_themes/openy_bouquet/templates/layout/page.html.twig
@@ -37,7 +37,7 @@
 #}
 <div class="layout-container">
 
-  <header class="bg-primary">
+  <header class="bg-openy-bouquet-blue">
     <div class="col-3 p-3 text-white {{ name_position }}">{{ association_name }}</div>
     {{ page.header }}
   </header>
@@ -51,7 +51,7 @@
 
   </main>
 
-  <footer role="contentinfo" class="bg-primary">
+  <footer role="contentinfo" class="bg-openy-bouquet-blue">
     {{ page.footer }}
     <div class="p-4 text-white">© 2020 YMCA of North Start</div>
   </footer>


### PR DESCRIPTION
## Steps for review

- [ ] Log in to a site and set the openy_bouquet theme as a default one.
- [ ] Ensure the header and footer regions' background color is "#0089d0".