### PR TITLE
[CR-74] Add white color to WYSIWYG colorbutton

### DIFF
--- a/modules/openy_features/openy_editor/config/install/editor.editor.full_html.yml
+++ b/modules/openy_features/openy_editor/config/install/editor.editor.full_html.yml
@@ -62,7 +62,7 @@ settings:
     stylescombo:
       styles: ''
     colorbutton:
-      colors: '5c2e91,92278f,c6168d,0060af,0089d0,00aeef,006b6b,01a490,20bdbe,dd5828,f47920,fcaf17,a92b31,ed1c24,f15922'
+      colors: '5c2e91,92278f,c6168d,0060af,0089d0,00aeef,006b6b,01a490,20bdbe,dd5828,f47920,fcaf17,a92b31,ed1c24,f15922,ffffff'
 image_upload:
   status: false
   scheme: public

--- a/modules/openy_features/openy_editor/openy_editor.install
+++ b/modules/openy_features/openy_editor/openy_editor.install
@@ -44,3 +44,12 @@ function openy_editor_update_8003() {
   \Drupal::service('module_installer')->install(['ckeditor_font'], TRUE);
   openy_editor_update_8002();
 }
+
+/**
+ * Update editor settings to add white text color.
+ */
+function openy_editor_update_8004() {
+  $config = drupal_get_path('module', 'openy_editor') . '/config/install/editor.editor.full_html.yml';
+  $config_importer = \Drupal::service('openy_upgrade_tool.param_updater');
+  $config_importer->update($config, 'editor.editor.full_html', 'settings.plugins.colorbutton.colors');
+}


### PR DESCRIPTION
Original Issue, this PR is going to fix: https://fivejars.atlassian.net/browse/CR-74

## Steps for review

- [ ] Log in to a site.
- [ ] Edit page layout.
- [ ] Some Basic block.
- [ ] Ensure the white color is available to be set as text color in the WYSIWYG editor.